### PR TITLE
Feature/next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,278 @@
         "node": ">=24.0.0"
       }
     },
+    "node_modules/@antoniomuso/lz4-napi-android-arm-eabi": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm-eabi/-/lz4-napi-android-arm-eabi-2.9.1.tgz",
+      "integrity": "sha512-KcRvkSOymDvxFDT9AGFBc7g+J/Xv4qExMMHhtxjZ45qE2sEIVCXoSFmyLDiVVKztkVzoV24VXPPRLOa4WQOi2Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-android-arm64": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm64/-/lz4-napi-android-arm64-2.9.1.tgz",
+      "integrity": "sha512-BNiddtI+5Z83w1jIufTFhTPrtxMVKb0UPezTq47XIE/7vkB6y5mHSWSlcHqEIFFIg2/PVdqyqec1CXv0bkpCPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-darwin-arm64": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-arm64/-/lz4-napi-darwin-arm64-2.9.1.tgz",
+      "integrity": "sha512-nhLu+8g8Q6Yqd0rxRn4JkCMJBUs6mByiyT3Mhha2EgorsA2txx18JKm9qLhnXpDgFGWc94tLEVHqzDk0tLD9yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-darwin-x64": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-x64/-/lz4-napi-darwin-x64-2.9.1.tgz",
+      "integrity": "sha512-DqkN1D/IrqOaUBppCP7BrF9j5Usb6RqFyz16kf3SHPDxLG7pmemgwXmGWpcNrKQfp4Shx1VkbFWA61gMyE1+uw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-freebsd-x64": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-freebsd-x64/-/lz4-napi-freebsd-x64-2.9.1.tgz",
+      "integrity": "sha512-ORtZ27l+j0yDgPMgt9q/j10LCchtKS44gFohEWl8fokgr5rzDAYAtMyQZzHV8sqE2LUWHAU3Gk6Wh9s1GRl9ow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm-gnueabihf": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm-gnueabihf/-/lz4-napi-linux-arm-gnueabihf-2.9.1.tgz",
+      "integrity": "sha512-GBZgQ/rY0AzjZA4jOKFXmLQKVPGXglVZ3U7SLcCu2nmuHTO73vsqiPeAHnYu7/org1km7yw3ii6XFlBRzyNKIA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm64-gnu": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-gnu/-/lz4-napi-linux-arm64-gnu-2.9.1.tgz",
+      "integrity": "sha512-9lvGts14KHNT4pc9lKYUPI1PRdBkfbyT4HCjyDk8fJJzEG9ryvLvyhTeFr/IVpJOFmkSodZw1nxJMQDT5+zvlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm64-musl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-musl/-/lz4-napi-linux-arm64-musl-2.9.1.tgz",
+      "integrity": "sha512-SsidKyLRHGB/rrgic+N7ZxFjjl+Cbav2sbuSj4AJsc37oVhyjzbiI5EEL9Rl+zL4ajL0d3utG3UbIUooThhykQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-ppc64-gnu": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-ppc64-gnu/-/lz4-napi-linux-ppc64-gnu-2.9.1.tgz",
+      "integrity": "sha512-1Joz9RmBLiLIfI5Gk/wmJI/WwQy74prKDhLcCPFoa/FcTOJavJAopAzs1MQdnM7nGklEPOpKZWmKHZz1yQ4LMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-riscv64-gnu": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-riscv64-gnu/-/lz4-napi-linux-riscv64-gnu-2.9.1.tgz",
+      "integrity": "sha512-3z6jSvhEpnSMlubcHwSn6W8Xziq5LYSuIcSpSo7wTEOopnr6GNnKcH2uTPFsRiqC/aC2TLpm17ktXbYTrYL7jg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-s390x-gnu": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-s390x-gnu/-/lz4-napi-linux-s390x-gnu-2.9.1.tgz",
+      "integrity": "sha512-wtQg/ikF1JutKdWfUdGXvR0LG+eG49mS01luwJXG6sg40DX737T3BAsbjM9Fccvif5jQwC+KmzP8+tvxy2eMtQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-x64-gnu": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-gnu/-/lz4-napi-linux-x64-gnu-2.9.1.tgz",
+      "integrity": "sha512-Vw7vb3i1Q6QU2sI5GdgZdi4cVwN2xZ44Gw/WawIxCno1gX39VIF/j8T1pYwS7Dc67NeoA37LsYIPb3h49CiRRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-x64-musl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-musl/-/lz4-napi-linux-x64-musl-2.9.1.tgz",
+      "integrity": "sha512-oZVrvOPjnI7c07v1lx6HMLFi8xlW9WS0pHmkaisldybNUWmNI6vR44KoqBctGCFplvF5YVMK2xPs3W04UGzF8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-openharmony-arm64": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-openharmony-arm64/-/lz4-napi-openharmony-arm64-2.9.1.tgz",
+      "integrity": "sha512-mkDQv6C0JbMbCDn070Dv67SWfkDy8uD6DkqUT373LHjdaEXj/0eK2gAVykKyPdnC1RBhONgUCaV4HQOp63oH8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-arm64-msvc": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-arm64-msvc/-/lz4-napi-win32-arm64-msvc-2.9.1.tgz",
+      "integrity": "sha512-EBsN9YzV3xpSPr6h/t6ntBetpdtO0nZw9o4sZ1vNOfLJ8FMdHxHiY7FonzhEyTnc4N3x3yMqPudD6zLVy/oNXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-ia32-msvc": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-ia32-msvc/-/lz4-napi-win32-ia32-msvc-2.9.1.tgz",
+      "integrity": "sha512-Fqe2JmcfjvVrC+BHjHPzoiIzNgjHpQvDO7duMbJh5fW9VvF7pKkjRAPDwhtFhkU/fBLVQywq5WbsFqtJ3pYG/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-x64-msvc": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-x64-msvc/-/lz4-napi-win32-x64-msvc-2.9.1.tgz",
+      "integrity": "sha512-N6bAJ4pcYfbiuysHNyEl6uVnYxl0CBboPeA6Iz1GQWJb6mp8J/z4+E8bTvasMuRhIhEW5F6X+oJIwmOwSzHoIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -2622,6 +2894,34 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/lz4-napi": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/lz4-napi/-/lz4-napi-2.9.1.tgz",
+      "integrity": "sha512-VjY1TAUQa3bo8j4vCcpQ0RBXh4mbC1OFHWH9rpOvx8qLYwaZTEzwxW/648ufD2cmz5/pFfPLDkX6N8+TqI9BYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@antoniomuso/lz4-napi-android-arm-eabi": "2.9.1",
+        "@antoniomuso/lz4-napi-android-arm64": "2.9.1",
+        "@antoniomuso/lz4-napi-darwin-arm64": "2.9.1",
+        "@antoniomuso/lz4-napi-darwin-x64": "2.9.1",
+        "@antoniomuso/lz4-napi-freebsd-x64": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-arm-gnueabihf": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-arm64-gnu": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-arm64-musl": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-ppc64-gnu": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-riscv64-gnu": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-s390x-gnu": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-x64-gnu": "2.9.1",
+        "@antoniomuso/lz4-napi-linux-x64-musl": "2.9.1",
+        "@antoniomuso/lz4-napi-openharmony-arm64": "2.9.1",
+        "@antoniomuso/lz4-napi-win32-arm64-msvc": "2.9.1",
+        "@antoniomuso/lz4-napi-win32-ia32-msvc": "2.9.1",
+        "@antoniomuso/lz4-napi-win32-x64-msvc": "2.9.1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3895,7 +4195,7 @@
     },
     "src/api": {
       "name": "@mayhem93/nexxus-api-lib",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MPL-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -3921,9 +4221,9 @@
         "typescript": "^6.0.0"
       },
       "peerDependencies": {
-        "@mayhem93/nexxus-core-lib": "~0.0.6",
-        "@mayhem93/nexxus-database-lib": "~0.0.7",
-        "@mayhem93/nexxus-message-queue-lib": "~0.0.6",
+        "@mayhem93/nexxus-core-lib": "~0.0.7",
+        "@mayhem93/nexxus-database-lib": "~0.0.8",
+        "@mayhem93/nexxus-message-queue-lib": "~0.0.7",
         "@mayhem93/nexxus-redis": "~0.0.7"
       }
     },
@@ -3951,7 +4251,7 @@
     },
     "src/core": {
       "name": "@mayhem93/nexxus-core-lib",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MPL-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.8",
@@ -3993,7 +4293,7 @@
     },
     "src/database": {
       "name": "@mayhem93/nexxus-database-lib",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MPL-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^8.19.1",
@@ -4013,7 +4313,7 @@
         "typescript": "^6.0.0"
       },
       "peerDependencies": {
-        "@mayhem93/nexxus-core-lib": "~0.0.6"
+        "@mayhem93/nexxus-core-lib": "~0.0.7"
       }
     },
     "src/database/node_modules/ajv": {
@@ -4040,11 +4340,12 @@
     },
     "src/message_queue": {
       "name": "@mayhem93/nexxus-message-queue-lib",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MPL-2.0",
       "peer": true,
       "dependencies": {
         "amqplib": "^0.10.9",
+        "lz4-napi": "^2.8.0",
         "tslib": "2.8.1"
       },
       "devDependencies": {
@@ -4055,7 +4356,7 @@
         "typescript": "^6.0.0"
       },
       "peerDependencies": {
-        "@mayhem93/nexxus-core-lib": "~0.0.6"
+        "@mayhem93/nexxus-core-lib": "~0.0.7"
       }
     },
     "src/redis": {
@@ -4081,7 +4382,7 @@
     },
     "src/worker": {
       "name": "@mayhem93/nexxus-worker-lib",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MPL-2.0",
       "dependencies": {
         "dot-prop": "^10.1.0",
@@ -4093,9 +4394,9 @@
         "typescript": "^6.0.0"
       },
       "peerDependencies": {
-        "@mayhem93/nexxus-core-lib": "~0.0.6",
-        "@mayhem93/nexxus-database-lib": "~0.0.7",
-        "@mayhem93/nexxus-message-queue-lib": "~0.0.6",
+        "@mayhem93/nexxus-core-lib": "~0.0.7",
+        "@mayhem93/nexxus-database-lib": "~0.0.8",
+        "@mayhem93/nexxus-message-queue-lib": "~0.0.7",
         "@mayhem93/nexxus-redis": "~0.0.7"
       }
     }

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mayhem93/nexxus-api-lib",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "API library for the Nexxus backend",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -40,9 +40,9 @@
     "tslib": "2.8.1"
   },
   "peerDependencies": {
-    "@mayhem93/nexxus-core-lib": "~0.0.6",
-    "@mayhem93/nexxus-database-lib": "~0.0.7",
-    "@mayhem93/nexxus-message-queue-lib": "~0.0.6",
+    "@mayhem93/nexxus-core-lib": "~0.0.7",
+    "@mayhem93/nexxus-database-lib": "~0.0.8",
+    "@mayhem93/nexxus-message-queue-lib": "~0.0.7",
     "@mayhem93/nexxus-redis": "~0.0.7"
   },
   "devDependencies": {

--- a/src/api/src/lib/Api.ts
+++ b/src/api/src/lib/Api.ts
@@ -44,7 +44,8 @@ import {
   NotFoundMiddleware,
   ErrorMiddleware,
   RequestLoggerMiddleware,
-  RequiredHeadersMiddleware
+  RequiredHeadersMiddleware,
+  AppExistsMiddleware
 } from './middlewares';
 import {
   NexxusAuthStrategy,
@@ -622,6 +623,7 @@ export class NexxusApi extends NexxusBaseService<NexxusApiConfig, {}, NexxusApiS
       this.express.post(
         `/auth/${name}`,
         RequiredHeadersMiddleware('nxx-app-id') as Express.RequestHandler,
+        AppExistsMiddleware() as Express.RequestHandler,
         (req, res, next) => {
           const appId = req.headers['nxx-app-id'] as string;
           const strategy = this.getAppAuthStrategy(appId, name);

--- a/src/api/src/lib/ModelQueryValidation.ts
+++ b/src/api/src/lib/ModelQueryValidation.ts
@@ -1,0 +1,147 @@
+import {
+  InvalidQueryFilterException,
+  NexxusApplication,
+  NexxusFilterQuery,
+  NexxusFilterQueryType,
+} from '@mayhem93/nexxus-core-lib';
+
+import { NexxusApi, type NexxusApiRequest } from './Api';
+import {
+  InvalidParametersException,
+  ModelNotFoundException,
+} from './Exceptions';
+
+/**
+ * The shared bits of "read-shaped" request validation across model-facing
+ * routes (subscribe, unsubscribe, search, count). Every one of these takes
+ * `{ model, id?, userId?, filter? }` in the request body, validates it
+ * against the app's schema, and materializes a `NexxusFilterQuery` — this
+ * function is the single implementation.
+ *
+ * Pagination (`limit` / `offset`) is deliberately NOT handled here — only
+ * the search route uses it, so it stays inline there.
+ */
+export interface ValidatedModelQuery {
+  appId: string;
+  app: NexxusApplication;
+  model: string;
+  id?: string;
+  userId?: string;
+  /**
+   * The caller's filter, validated + wrapped as a `NexxusFilterQuery`.
+   * Does NOT include the id/userId merge — callers that want to search
+   * the DB should build a separate "database filter" by folding id and
+   * userId in; callers that only want a subscription filter (matching
+   * against future updates) use this one as-is.
+   */
+  filter?: NexxusFilterQuery;
+}
+
+interface ModelQueryBody {
+  id?: string;
+  userId?: string;
+  filter?: NexxusFilterQueryType;
+}
+
+/**
+ * Validate the shared read-shaped request params and materialize the
+ * `NexxusFilterQuery`. `model` is passed separately because different
+ * routes source it from different places (URL param on search, body on
+ * subscribe/unsubscribe).
+ *
+ * Throws `InvalidParametersException` / `ModelNotFoundException` on any
+ * validation failure — routes let those propagate to the error middleware.
+ */
+export function validateModelQueryParams(
+  req: NexxusApiRequest,
+  body: ModelQueryBody,
+  model: string,
+): ValidatedModelQuery {
+  const appId = req.headers['nxx-app-id'] as string;
+  const app = NexxusApi.getStoredApp(appId)!;
+  const appSchema = app.getData().schema;
+
+  if (!model || typeof model !== 'string') {
+    throw new InvalidParametersException('Invalid model parameter');
+  }
+
+  if (appSchema[model] === undefined) {
+    throw new ModelNotFoundException(`Model "${model}" not found in application "${appId}"`);
+  }
+
+  if (typeof body.id !== 'string' && body.id !== undefined) {
+    throw new InvalidParametersException('Invalid modelId parameter');
+  }
+
+  if (body.userId !== undefined) {
+    if (typeof body.userId !== 'string') {
+      throw new InvalidParametersException('Invalid userId parameter');
+    }
+
+    if (!app.hasAuthEnabled()) {
+      throw new InvalidParametersException(
+        'userId parameter cannot be used when authentication is disabled for this application',
+      );
+    }
+  }
+
+  if (body.id !== undefined && body.userId !== undefined) {
+    throw new InvalidParametersException('Redundant modelId and userId parameters provided');
+  }
+
+  let filter: NexxusFilterQuery | undefined;
+
+  if (body.filter !== undefined) {
+    if (typeof body.filter !== 'object') {
+      throw new InvalidParametersException('Invalid filter parameter');
+    }
+
+    try {
+      filter = new NexxusFilterQuery(body.filter, app.getAppModelSchema(model));
+    } catch (e) {
+      if (e instanceof InvalidQueryFilterException) {
+        throw new InvalidParametersException(`Invalid filter parameter: ${e.message}`);
+      }
+
+      throw e;
+    }
+  }
+
+  return { appId, app, model, id: body.id, userId: body.userId, filter };
+}
+
+/**
+ * Fold id + userId into a copy of the user's filter to produce the
+ * database filter — separate from the subscription filter, which stays
+ * user-provided so it matches only against the fields the client
+ * actually cares about (not the framework-injected id/userId).
+ *
+ * Returns undefined when the caller supplied nothing (no filter, no id,
+ * no userId) — the caller can then skip building a DB filter entirely.
+ */
+export function buildDatabaseFilter(
+  validated: ValidatedModelQuery,
+  rawFilter: NexxusFilterQueryType | undefined,
+): NexxusFilterQuery | undefined {
+  const { app, model, id, userId } = validated;
+
+  if (rawFilter === undefined && id === undefined && userId === undefined) {
+    return undefined;
+  }
+
+  const dbFilterInput: NexxusFilterQueryType = {
+    ...structuredClone(rawFilter ?? {}),
+    ...(id && { id }),
+    ...(userId && { userId }),
+  };
+
+  try {
+    return new NexxusFilterQuery(dbFilterInput, app.getAppModelSchema(model));
+  } catch (e) {
+    if (e instanceof InvalidQueryFilterException) {
+      throw new InvalidParametersException(`Invalid filter parameter: ${e.message}`);
+    }
+
+    throw e;
+  }
+}

--- a/src/api/src/lib/routes/Model.ts
+++ b/src/api/src/lib/routes/Model.ts
@@ -2,6 +2,7 @@ import { InvalidParametersException, ModelNotFoundException } from '../Exception
 import { NexxusApiBaseRoute } from '../BaseRoute';
 import { type NexxusApiRequest, type NexxusApiResponse, NexxusApi } from '../Api';
 import { RequiredHeadersMiddleware, AppExistsMiddleware, AuthMiddleware } from '../middlewares';
+import { validateModelQueryParams, buildDatabaseFilter } from '../ModelQueryValidation';
 import {
   NexxusAppModel,
   NexxusJsonPatch,
@@ -15,6 +16,21 @@ import {
 } from '@mayhem93/nexxus-core-lib';
 
 import type { Router, RequestHandler } from 'express';
+
+type SearchModelRequestBody = {
+  id?: string;
+  userId?: string;
+  filter?: NexxusFilterQueryType;
+  limit?: number;
+  offset?: number;
+};
+
+interface SearchModelRequest extends NexxusApiRequest {
+  body: SearchModelRequestBody;
+  params: {
+    type: string;
+  };
+}
 
 interface GetModelRequest extends NexxusApiRequest {
   params: {
@@ -82,6 +98,53 @@ export default class ModelRoute extends NexxusApiBaseRoute {
     this.router.post('/count',
       this.countModel.bind(this) as RequestHandler<any, any, CountModelRequestBody>
     );
+    this.router.post('/:type/search',
+      this.searchModel.bind(this) as RequestHandler<SearchModelRequest['params'], any, SearchModelRequest['body']>
+    );
+  }
+
+  /**
+   * Traditional search — no subscription side-effect. Model type comes
+   * from the URL param; filter / pagination / id / userId from the body.
+   * Shared validation with subscribe/unsubscribe lives in
+   * `ModelQueryValidation.validateModelQueryParams`.
+   */
+  private async searchModel(req: SearchModelRequest, res: NexxusApiResponse): Promise<void> {
+    const validated = validateModelQueryParams(req, req.body, req.params.type);
+    const { appId, app, model } = validated;
+
+    // Pagination — kept inline because only this route uses it.
+    let limit = req.body.limit;
+
+    if (limit !== undefined && (typeof limit !== 'number' || limit <= 0)) {
+      throw new InvalidParametersException('Invalid limit parameter');
+    }
+
+    limit = limit ?? app.getData().defaultLimit;
+
+    if (limit! > app.getData().maxLimit!) {
+      throw new InvalidParametersException(`Limit parameter exceeds maximum allowed value (${app.getData().maxLimit})`);
+    }
+
+    let offset = req.body.offset;
+
+    if (offset === undefined) {
+      offset = 0;
+    } else if (typeof offset !== 'number' || offset < 0) {
+      throw new InvalidParametersException('Invalid offset parameter');
+    }
+
+    const databaseFilter = buildDatabaseFilter(validated, req.body.filter);
+
+    const results = (await NexxusApi.database.searchItems({
+      appId,
+      type: model,
+      filter: databaseFilter,
+      limit,
+      offset,
+    })).map(item => item.getData());
+
+    res.status(200).send({ data: { items: results } });
   }
 
   private async getModel(req: GetModelRequest, res: NexxusApiResponse): Promise<void> {
@@ -111,7 +174,8 @@ export default class ModelRoute extends NexxusApiBaseRoute {
 
   private async createModel(req: CreateAppModelRequest, res: NexxusApiResponse): Promise<void> {
     const appId = req.headers['nxx-app-id'] as string;
-    const appSchema = NexxusApi.getStoredApp(appId)?.getSchema() as NexxusApplicationSchema;
+    const app = NexxusApi.getStoredApp(appId)!;
+    const appSchema = app.getSchema();
 
     if (!appSchema[req.body.type]) {
       throw new ModelNotFoundException(`Model "${req.body.type}" not found in schema for the application "${appId}"`);
@@ -123,17 +187,39 @@ export default class ModelRoute extends NexxusApiBaseRoute {
       userId: req.user?.id
     }, appSchema);
 
-    await NexxusApi.messageQueue.publishMessage('writer', { event: 'model_created', data: newModel.getData() });
+    // Transient models bypass the writer entirely — their records are
+    // notification-shaped, existing only long enough to fan out to
+    // subscribers. Publishing directly to transport-manager saves the
+    // DB write and the writer's re-validate hop. The payload shape is
+    // identical (both queues accept NexxusModelCreatedPayload).
+    if (app.isTransient(req.body.type)) {
+      await NexxusApi.messageQueue.publishMessage('transport-manager', {
+        event: 'model_created',
+        data: newModel.getData(),
+      });
+    } else {
+      await NexxusApi.messageQueue.publishMessage('writer', {
+        event: 'model_created',
+        data: newModel.getData(),
+      });
+    }
 
     res.status(202).send({ message: 'Model created successfully!' });
   }
 
   private async updateModel(req: UpdateAppModelRequest, res: NexxusApiResponse): Promise<void> {
     const appId = req.headers['nxx-app-id'] as string;
-    const appSchema = NexxusApi.getStoredApp(appId)?.getSchema() as NexxusApplicationSchema;
+    const app = NexxusApi.getStoredApp(appId)!;
+    const appSchema = app.getSchema();
 
     if (!appSchema[req.body.type]) {
       throw new ModelNotFoundException(`Model "${req.body.type}" not found in schema for the application "${appId}"`);
+    }
+
+    if (app.isTransient(req.body.type)) {
+      throw new InvalidParametersException(
+        `Model "${req.body.type}" is transient (create-only) and cannot be updated`
+      );
     }
 
     try {
@@ -163,10 +249,17 @@ export default class ModelRoute extends NexxusApiBaseRoute {
 
   private async deleteModel(req: DeleteAppModelRequest, res: NexxusApiResponse): Promise<void> {
     const appId = req.headers['nxx-app-id'] as string;
-    const appSchema = NexxusApi.getStoredApp(appId)?.getSchema() as NexxusApplicationSchema;
+    const app = NexxusApi.getStoredApp(appId)!;
+    const appSchema = app.getSchema();
 
     if (!appSchema[req.body.type]) {
       throw new ModelNotFoundException(`Model "${req.body.type}" not found in schema for the application "${appId}"`);
+    }
+
+    if (app.isTransient(req.body.type)) {
+      throw new InvalidParametersException(
+        `Model "${req.body.type}" is transient (create-only) and cannot be deleted`
+      );
     }
 
     await NexxusApi.messageQueue.publishMessage('writer', { event: 'model_deleted', data: {

--- a/src/api/src/lib/routes/Subscription.ts
+++ b/src/api/src/lib/routes/Subscription.ts
@@ -7,20 +7,16 @@ import {
 import {
   type NexxusApiRequest,
   type NexxusApiResponse,
-  NexxusApi
+  NexxusApi,
 } from '../Api';
 import {
   InvalidParametersException,
   NotFoundException,
-  ModelNotFoundException,
   DeviceNotConnectedException
 } from '../Exceptions';
+import { validateModelQueryParams, buildDatabaseFilter } from '../ModelQueryValidation';
 
-import {
-  InvalidQueryFilterException,
-  NexxusFilterQuery,
-  NexxusFilterQueryType
-} from '@mayhem93/nexxus-core-lib';
+import { NexxusFilterQueryType } from '@mayhem93/nexxus-core-lib';
 import {
   RedisKeyNotFoundException,
   NexxusRedisSubscription,
@@ -35,12 +31,11 @@ type SubscribeRequestBody = {
   userId?: string;
   id?: string;
   filter?: NexxusFilterQueryType;
-  getOnly?: boolean;
   limit?: number;
   offset?: number;
 };
 
-type UnsubscribeRequestBody = Omit<SubscribeRequestBody, 'limit' | 'offset' | 'getOnly'>;
+type UnsubscribeRequestBody = Omit<SubscribeRequestBody, 'limit' | 'offset'>;
 
 interface SubscribeRequest extends NexxusApiRequest {
   body: SubscribeRequestBody;
@@ -68,199 +63,89 @@ export default class SubscriptionRoute extends NexxusApiBaseRoute {
   }
 
   private async subscribe(req: SubscribeRequest, res: NexxusApiResponse): Promise<void> {
-    const appId = req.headers['nxx-app-id'] as string;
-    const app = NexxusApi.getStoredApp(appId);
-    const appSchema = app!.getData().schema;
     const deviceId = req.headers['nxx-device-id'] as string;
-    const responseBody: Record<string, any> = { data: {} };
 
-    if (!req.body.model || typeof req.body.model !== 'string') {
-      throw new InvalidParametersException('Invalid model parameter');
+    const validated = validateModelQueryParams(req, req.body, req.body.model);
+    const { appId, app, model, id, userId, filter } = validated;
+
+    if (!app.isSubscribable(model)) {
+      throw new InvalidParametersException(
+        `Model "${model}" is not subscribable — use the search endpoint (POST /model/${model}/search) instead`
+      );
     }
 
-    if (appSchema[req.body.model] === undefined) {
-      throw new ModelNotFoundException(`Model "${req.body.model}" not found in application "${appId}"`);
+    // Pagination — kept inline (only routes returning items use it).
+    let limit = req.body.limit;
+
+    if (limit !== undefined && (typeof limit !== 'number' || limit <= 0)) {
+      throw new InvalidParametersException('Invalid limit parameter');
     }
 
-    if (typeof req.body.id !== 'string' && req.body.id !== undefined) {
-      throw new InvalidParametersException('Invalid modelId parameter');
+    limit = limit ?? app.getData().defaultLimit;
+
+    if (limit! > app.getData().maxLimit!) {
+      throw new InvalidParametersException(`Limit parameter exceeds maximum allowed value (${app.getData().maxLimit})`);
     }
 
-    if (req.body.userId !== undefined) {
-      if (typeof req.body.userId !== 'string') {
-        throw new InvalidParametersException('Invalid userId parameter');
+    let offset = req.body.offset;
+
+    if (offset === undefined) {
+      offset = 0;
+    } else if (typeof offset !== 'number' || offset < 0) {
+      throw new InvalidParametersException('Invalid offset parameter');
+    }
+
+    const sub = new NexxusRedisSubscription({
+      appId,
+      model,
+      modelId: id,
+      userId,
+      filter,
+    });
+
+    try {
+      const device = await NexxusDevice.get(deviceId, true);
+
+      await device.addSubscription(sub);
+    } catch (e) {
+      if (e instanceof RedisKeyNotFoundException) {
+        throw new NotFoundException(`Device with id "${deviceId}" not found`);
+      } else if (e instanceof RedisDeviceNotConnectedException) {
+        throw new DeviceNotConnectedException(`Device with id "${deviceId}" is not connected to any transport`);
       }
 
-      if (!app!.hasAuthEnabled()) {
-        throw new InvalidParametersException('userId parameter cannot be used when authentication is disabled for this application');
-      }
+      throw e;
     }
 
-    if (req.body.id !== undefined && req.body.userId !== undefined) {
-      throw new InvalidParametersException('Redundant modelId and userId parameters provided');
-    }
-
-    if (typeof req.body.getOnly !== 'boolean' && req.body.getOnly !== undefined) {
-      throw new InvalidParametersException('Invalid getOnly parameter');
-    }
-
-    req.body.getOnly = req.body.getOnly || false;
-
-    if (!req.body.getOnly && req.body.limit !== undefined && req.body.offset !== undefined) {
-      throw new InvalidParametersException('Subscription intents should not contain pagination parameters. ' +
-        'Please set "getOnly" to true if you want to use pagination parameters to get a snapshot of the data without subscribing to changes') ;
-    }
-
-    if (req.body.limit !== undefined && (typeof req.body.limit !== 'number' || req.body.limit <= 0)) {
-        throw new InvalidParametersException('Invalid limit parameter');
-    }
-
-    req.body.limit = req.body.limit || app?.getData().defaultLimit;
-
-    if (req.body.limit! > app?.getData().maxLimit!) {
-        throw new InvalidParametersException(`Limit parameter exceeds maximum allowed value (${app?.getData().maxLimit})`);
-    }
-
-    if (req.body.offset === undefined) {
-      req.body.offset = 0;
-    } else {
-      if (typeof req.body.offset !== 'number' || req.body.offset < 0) {
-        throw new InvalidParametersException('Invalid offset parameter');
-      }
-    }
-
-    let subscriptionFilter: NexxusFilterQuery | undefined;
-
-    if (req.body.filter !== undefined) {
-      if (typeof req.body.filter !== 'object') {
-        throw new InvalidParametersException('Invalid filter parameter');
-      }
-
-      try {
-        subscriptionFilter = new NexxusFilterQuery(req.body.filter, NexxusApi.getStoredApp(appId)!.getAppModelSchema(req.body.model));
-      } catch (e) {
-        if (e instanceof InvalidQueryFilterException) {
-          throw new InvalidParametersException(`Invalid filter parameter: ${e.message}`);
-        }
-
-        throw e;
-      }
-    }
-
-    let databaseFilter: NexxusFilterQuery | undefined;
-
-    //we merge "id" and "userId" queries to a db filter since these two are handled separately in the request
-    if (req.body.filter !== undefined || req.body.id !== undefined || req.body.userId !== undefined) {
-      const dbFilterInput: NexxusFilterQueryType = {
-        ...structuredClone(req.body.filter || {}),
-        ...(req.body.id && { id: req.body.id }),
-        ...(req.body.userId && { userId: req.body.userId })
-      };
-
-      try {
-        databaseFilter = new NexxusFilterQuery(dbFilterInput, NexxusApi.getStoredApp(appId)!.getAppModelSchema(req.body.model));
-      } catch (e) {
-        if (e instanceof InvalidQueryFilterException) {
-          throw new InvalidParametersException(`Invalid filter parameter: ${e.message}`);
-        }
-        throw e;
-      }
-    }
-
-    if (req.body.getOnly === false) {
-      const sub = new NexxusRedisSubscription({
-        appId,
-        model: req.body.model,
-        modelId: req.body.id,
-        userId: req.body.userId,
-        filter: subscriptionFilter
-      });
-
-      try {
-        const device = await NexxusDevice.get(deviceId, true);
-
-        await device.addSubscription(sub);
-
-        responseBody.data.channelId = sub.getKey();
-      } catch (e) {
-        if (e instanceof RedisKeyNotFoundException) {
-          throw new NotFoundException(`Device with id "${deviceId}" not found`);
-        } else if (e instanceof RedisDeviceNotConnectedException) {
-          throw new DeviceNotConnectedException(`Device with id "${deviceId}" is not connected to any transport`);
-        }
-
-        throw e;
-      }
-    }
+    // Atomic subscribe + return initial data. `forceRefresh` matches the
+    // previous getOnly=false behavior — we've just recorded a subscription
+    // and want the initial page to be consistent with any in-flight writes.
+    const databaseFilter = buildDatabaseFilter(validated, req.body.filter);
 
     const results = (await NexxusApi.database.searchItems({
       appId,
-      type: req.body.model,
+      type: model,
       filter: databaseFilter,
-      limit: req.body.limit,
-      offset: req.body.offset,
+      limit,
+      offset,
       databaseSpecific: {
-        forceRefresh: req.body.getOnly === false
-      }
+        forceRefresh: true,
+      },
     })).map(item => item.getData());
 
-    responseBody.data.items = results;
-
-    res.status(200).send(responseBody);
+    res.status(200).send({ data: { channelId: sub.getKey(), items: results } });
   }
 
   private async unsubscribe(req: UnsubscribeRequest, res: NexxusApiResponse): Promise<void> {
-    const appId = req.headers['nxx-app-id'] as string;
-    const app = NexxusApi.getStoredApp(appId);
-    const appSchema = app!.getData().schema;
     const deviceId = req.headers['nxx-device-id'] as string;
 
-    // Validation — duplicated from `subscribe()` sans pagination/getOnly. The two
-    // handlers must identify the same channel (the Redis key is derived from
-    // these fields), so they MUST validate the inputs identically. Extract into
-    // a shared helper when we revisit this.
-    if (!req.body.model || typeof req.body.model !== 'string') {
-      throw new InvalidParametersException('Invalid model parameter');
-    }
+    const validated = validateModelQueryParams(req, req.body, req.body.model);
+    const { appId, app, model, id, userId, filter } = validated;
 
-    if (appSchema[req.body.model] === undefined) {
-      throw new ModelNotFoundException(`Model "${req.body.model}" not found in application "${appId}"`);
-    }
-
-    if (typeof req.body.id !== 'string' && req.body.id !== undefined) {
-      throw new InvalidParametersException('Invalid modelId parameter');
-    }
-
-    if (req.body.userId !== undefined) {
-      if (typeof req.body.userId !== 'string') {
-        throw new InvalidParametersException('Invalid userId parameter');
-      }
-
-      if (!app!.hasAuthEnabled()) {
-        throw new InvalidParametersException('userId parameter cannot be used when authentication is disabled for this application');
-      }
-    }
-
-    if (req.body.id !== undefined && req.body.userId !== undefined) {
-      throw new InvalidParametersException('Redundant modelId and userId parameters provided');
-    }
-
-    let subscriptionFilter: NexxusFilterQuery | undefined;
-
-    if (req.body.filter !== undefined) {
-      if (typeof req.body.filter !== 'object') {
-        throw new InvalidParametersException('Invalid filter parameter');
-      }
-
-      try {
-        subscriptionFilter = new NexxusFilterQuery(req.body.filter, app!.getAppModelSchema(req.body.model));
-      } catch (e) {
-        if (e instanceof InvalidQueryFilterException) {
-          throw new InvalidParametersException(`Invalid filter parameter: ${e.message}`);
-        }
-
-        throw e;
-      }
+    if (!app.isSubscribable(model)) {
+      throw new InvalidParametersException(
+        `Model "${model}" is not subscribable — nothing to unsubscribe from`
+      );
     }
 
     // Rebuild the same descriptor the SDK used at subscribe time — the resulting
@@ -268,10 +153,10 @@ export default class SubscriptionRoute extends NexxusApiBaseRoute {
     // inputs find the same subscription record.
     const sub = new NexxusRedisSubscription({
       appId,
-      model: req.body.model,
-      modelId: req.body.id,
-      userId: req.body.userId,
-      filter: subscriptionFilter
+      model,
+      modelId: id,
+      userId,
+      filter,
     });
 
     let removed: boolean;

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mayhem93/nexxus-core-lib",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Core types and structures used by other Nexxus packages",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",

--- a/src/core/src/common/FilterQuery.ts
+++ b/src/core/src/common/FilterQuery.ts
@@ -284,9 +284,9 @@ export class NexxusFilterQuery {
     const comparisonOps: NexxusComparisonOperator[] = ['gte', 'lte', 'gt', 'lt'];
 
     if (comparisonOps.includes(operator)) {
-      if (type !== 'number' && type !== 'date') {
+      if (!['int', 'float', 'date'].includes(type as string)) {
         throw new InvalidQueryFilterException(
-          `Operator "${operator}" at path "${path}" can only be used with number or date fields`
+          `Operator "${operator}" at path "${path}" can only be used with int, float or date fields`
         );
       }
     }
@@ -315,9 +315,15 @@ export class NexxusFilterQuery {
         }
         break;
 
-      case 'number':
-        if (typeof value !== 'number' || isNaN(value)) {
-          throw new InvalidQueryFilterException(`Value at path "${path}" must be a number`);
+      case 'int':
+        if (typeof value !== 'number' || !Number.isInteger(value)) {
+          throw new InvalidQueryFilterException(`Value at path "${path}" must be an integer`);
+        }
+        break;
+
+      case 'float':
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+          throw new InvalidQueryFilterException(`Value at path "${path}" must be a float`);
         }
         break;
 
@@ -327,7 +333,7 @@ export class NexxusFilterQuery {
         }
         break;
 
-      case 'date':
+      case 'date': {
         const isValidDate =
           (typeof value === 'number' && !isNaN(value)) || // Unix timestamp
           (typeof value === 'string' && !isNaN(Date.parse(value))); // ISO string
@@ -336,8 +342,9 @@ export class NexxusFilterQuery {
           throw new InvalidQueryFilterException(`Value at path "${path}" must be a Unix timestamp or ISO date string`);
         }
         break;
+      }
 
-      case 'array':
+      case 'array': {
         // For array fields, we check if the value matches the arrayType
         const arrayFieldDef = fieldDef as NexxusArrayFieldDef;
         const arrayType = arrayFieldDef.arrayType;
@@ -348,9 +355,14 @@ export class NexxusFilterQuery {
               throw new InvalidQueryFilterException(`Value at path "${path}" must be a string (array contains strings)`);
             }
             break;
-          case 'number':
-            if (typeof value !== 'number') {
-              throw new InvalidQueryFilterException(`Value at path "${path}" must be a number (array contains numbers)`);
+          case 'int':
+            if (typeof value !== 'number' || !Number.isInteger(value)) {
+              throw new InvalidQueryFilterException(`Value at path "${path}" must be an integer (array contains integers)`);
+            }
+            break;
+          case 'float':
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+              throw new InvalidQueryFilterException(`Value at path "${path}" must be a float (array contains floats)`);
             }
             break;
           case 'boolean':
@@ -366,7 +378,9 @@ export class NexxusFilterQuery {
           case 'object':
             throw new InvalidQueryFilterException(`Cannot query array of objects at path "${path}". Use dot notation for nested fields.`);
         }
+
         break;
+      }
 
       case 'object':
         throw new InvalidQueryFilterException(`Cannot query object field "${path}" directly. Use dot notation for nested fields.`);

--- a/src/core/src/common/InferModel.ts
+++ b/src/core/src/common/InferModel.ts
@@ -3,14 +3,16 @@
 
 export type InferFieldDef<D> =
   D extends { type: 'string' }  ? string  :
-  D extends { type: 'number' }  ? number  :
+  D extends { type: 'int' }     ? number  :
+  D extends { type: 'float' }   ? number  :
   D extends { type: 'boolean' } ? boolean :
   D extends { type: 'date' }    ? number  :
   D extends { type: 'array', arrayType: infer AT, properties?: infer P } ?
     AT extends 'object'
       ? P extends Record<string, any> ? Array<InferModel<P>> : never
       : AT extends 'string'  ? string[]
-      : AT extends 'number'  ? number[]
+      : AT extends 'int'     ? number[]
+      : AT extends 'float'   ? number[]
       : AT extends 'boolean' ? boolean[]
       : AT extends 'date'    ? number[]
       : never :

--- a/src/core/src/common/JsonPatch.ts
+++ b/src/core/src/common/JsonPatch.ts
@@ -70,7 +70,7 @@ export class NexxusJsonPatch {
 
   private static readonly OPERATION_RULES: Record<typeof JSON_OPS[number], OperationRule> = {
     replace: {
-      allowedTypes: ['string', 'number', 'boolean', 'date', 'object', 'array'],
+      allowedTypes: ['string', 'int', 'float', 'boolean', 'date', 'object', 'array'],
       validateValue: (value: any, fieldDef: NexxusFieldDef, path: string) =>
         NexxusSchemaValidator.validateValue(value, fieldDef, path)
     },
@@ -154,12 +154,12 @@ export class NexxusJsonPatch {
       }
     },
     incr: {
-      allowedTypes: ['number', 'date'],
+      allowedTypes: ['int', 'float', 'date'],
       validateValue: (value: any, fieldDef: NexxusFieldDef, path: string) =>
         NexxusSchemaValidator.validateValue(value, fieldDef, path)
     },
     decr: {
-      allowedTypes: ['number', 'date'],
+      allowedTypes: ['int', 'float', 'date'],
       validateValue: (value: any, fieldDef: NexxusFieldDef, path: string) =>
         NexxusSchemaValidator.validateValue(value, fieldDef, path)
     }

--- a/src/core/src/common/ModelTypes.ts
+++ b/src/core/src/common/ModelTypes.ts
@@ -1,4 +1,4 @@
-export type NexxusModelPrimitiveType = 'string' | 'number' | 'boolean' | 'date';
+export type NexxusModelPrimitiveType = 'string' | 'int' | 'float' | 'boolean' | 'date';
 export type NexxusModelFieldType = NexxusModelPrimitiveType | 'array' | 'object';
 
 interface BaseFieldDef {

--- a/src/core/src/common/SchemaValidator.ts
+++ b/src/core/src/common/SchemaValidator.ts
@@ -17,39 +17,61 @@ import { InvalidSchemaDataException } from '../lib/Exceptions';
  * Used by:
  *   - NexxusJsonPatch (per-path validation on patch operations)
  *   - NexxusAppModel (whole-model validation on construction)
- *
- * Required-field checking is intentionally NOT performed here yet; only fields
- * present in the input are validated.
  */
 export class NexxusSchemaValidator {
 
   /**
-   * Validate every present field of `data` against the model definition.
-   * Returns a shallow-merged copy of `data` with each value normalized.
-   * Unknown fields (present in data but not declared in modelDef) are passed
-   * through unchanged.
+   * Validate `data` against the model definition, enforcing `required` and
+   * the per-field type checks. Iterates the SCHEMA (not the data) so that
+   * required fields the caller omits entirely still get caught — the old
+   * data-iterating shape silently skipped them.
+   *
+   * Returns a shallow-merged copy of `data` with each declared value
+   * normalized. Unknown fields (present in data but not declared in
+   * modelDef) are passed through unchanged — the schema DSL is
+   * intentionally open (developers can add ad-hoc fields not covered
+   * by their declared schema).
    */
   public static validateAgainstSchema(data: Record<string, unknown>, modelDef: NexxusModelDef): Record<string, unknown> {
     if (!data || typeof data !== 'object' || Array.isArray(data)) {
       throw new InvalidSchemaDataException(`Schema validation: input must be a non-null object`);
     }
 
+    // `version` is set exclusively by the database adapter on writes;
+    // user input cannot supply it. Checked before the schema loop so it
+    // triggers regardless of whether the schema happens to declare it.
+    if ('version' in data) {
+      throw new InvalidSchemaDataException(
+        `Field "version" is a system-managed Nexxus field and cannot be set by user input`
+      );
+    }
+
     const result: Record<string, unknown> = { ...data };
 
-    for (const [fieldName, value] of Object.entries(data)) {
-      // `version` is set exclusively by the database adapter on writes;
-      // user input cannot supply it. If more system-managed fields join later,
-      // extract a NEXXUS_SYSTEM_MANAGED_FIELDS constant at that point.
-      if (fieldName === 'version') {
-        throw new InvalidSchemaDataException(
-          `Field "version" is a system-managed Nexxus field and cannot be set by user input`
-        );
+    for (const [fieldName, fieldDef] of Object.entries(modelDef)) {
+      const value = data[fieldName];
+      const absent = !(fieldName in data) || value === undefined;
+
+      if (absent) {
+        if (fieldDef.required === true) {
+          throw new InvalidSchemaDataException(
+            `Required field "${fieldName}" is missing`
+          );
+        }
+
+        continue;
       }
 
-      const fieldDef = modelDef[fieldName];
+      if (value === null) {
+        if (fieldDef.nullable === true) {
+          result[fieldName] = null;
 
-      if (!fieldDef) {
-        continue;
+          continue;
+        }
+
+        throw new InvalidSchemaDataException(
+          `Field "${fieldName}" cannot be null`
+        );
       }
 
       result[fieldName] = NexxusSchemaValidator.validateValue(value, fieldDef, fieldName);
@@ -163,10 +185,37 @@ export class NexxusSchemaValidator {
     const input = value as Record<string, unknown>;
     const result: Record<string, unknown> = { ...input };
 
+    // Same shape as `validateAgainstSchema`: iterate the schema so missing
+    // required nested fields are caught, and null/absent handling matches
+    // the top-level behaviour.
     for (const [key, propDef] of Object.entries(fieldDef.properties)) {
-      if (key in input) {
-        result[key] = NexxusSchemaValidator.validateValue(input[key], propDef, `${path}.${key}`);
+      const subPath = `${path}.${key}`;
+      const subValue = input[key];
+      const absent = !(key in input) || subValue === undefined;
+
+      if (absent) {
+        if (propDef.required === true) {
+          throw new InvalidSchemaDataException(
+            `Required field "${subPath}" is missing`
+          );
+        }
+
+        continue;
       }
+
+      if (subValue === null) {
+        if (propDef.nullable === true) {
+          result[key] = null;
+
+          continue;
+        }
+
+        throw new InvalidSchemaDataException(
+          `Field "${subPath}" cannot be null`
+        );
+      }
+
+      result[key] = NexxusSchemaValidator.validateValue(subValue, propDef, subPath);
     }
 
     return result;

--- a/src/core/src/common/SchemaValidator.ts
+++ b/src/core/src/common/SchemaValidator.ts
@@ -69,8 +69,11 @@ export class NexxusSchemaValidator {
       case 'string':
         return NexxusSchemaValidator.validateString(value, path);
 
-      case 'number':
-        return NexxusSchemaValidator.validateNumber(value, path);
+      case 'int':
+        return NexxusSchemaValidator.validateInt(value, path);
+
+      case 'float':
+        return NexxusSchemaValidator.validateFloat(value, path);
 
       case 'boolean':
         return NexxusSchemaValidator.validateBoolean(value, path);
@@ -97,9 +100,17 @@ export class NexxusSchemaValidator {
     return value;
   }
 
-  private static validateNumber(value: unknown, path: string): number {
+  private static validateInt(value: unknown, path: string): number {
+    if (typeof value !== 'number' || !Number.isInteger(value)) {
+      throw new InvalidSchemaDataException(`Expected integer at path "${path}", got ${typeof value}`);
+    }
+
+    return value;
+  }
+
+  private static validateFloat(value: unknown, path: string): number {
     if (typeof value !== 'number' || !Number.isFinite(value)) {
-      throw new InvalidSchemaDataException(`Expected number at path "${path}", got ${typeof value}`);
+      throw new InvalidSchemaDataException(`Expected float at path "${path}", got ${typeof value}`);
     }
 
     return value;

--- a/src/core/src/models/AppModel.ts
+++ b/src/core/src/models/AppModel.ts
@@ -53,7 +53,7 @@ export class NexxusAppModel extends NexxusBaseModel<INexxusAppModel> {
     // present in `props` are validated.
     const normalized = NexxusSchemaValidator.validateAgainstSchema(
       props as Record<string, unknown>,
-      modelDef
+      modelDef.fields
     );
 
     super(normalized as INexxusAppModel);

--- a/src/core/src/models/Application.ts
+++ b/src/core/src/models/Application.ts
@@ -3,15 +3,42 @@ import {
   MODEL_REGISTRY
 } from './BaseModel';
 import { NexxusBuiltinModel } from './BuiltinModel';
-import { NexxusFieldDef, NexxusModelDef } from '../common/ModelTypes';
+import {
+  NexxusFieldDef,
+  NexxusModelDef,
+  PrimitiveFieldDef
+} from '../common/ModelTypes';
 import { InferModel } from '../common/InferModel';
-import { NEXXUS_BUILTIN_MODEL_SCHEMAS, NEXXUS_RESERVED_FIELD_NAMES } from '../common/BuiltinSchemas';
+import {
+  NEXXUS_BUILTIN_MODEL_SCHEMAS,
+  NEXXUS_RESERVED_FIELD_NAMES
+} from '../common/BuiltinSchemas';
 import { NexxusUserDetailSchema } from './User';
 
 import * as Dot from 'dot-prop';
 
+/**
+ * Per-app-model definition. Wraps the field defs with per-model flags:
+ *   - `subscribable` (default true): whether the subscribe route accepts
+ *     this model. `false` = traditional-DB shape — search works, all
+ *     fields are treated as filterable, subscribe/unsubscribe 400.
+ *   - `transient` (default false): create-only. `true` = update/delete
+ *     routes 400. Meant for notification-shaped models where records are
+ *     produced once and consumed via subscribe/search.
+ *
+ * The combination `subscribable: false && transient: true` is invalid —
+ * a model that's create-only and can't be subscribed to has no useful
+ * shape (the caller can't be notified of new records and can't mutate
+ * existing ones). Rejected at construction.
+ */
+export interface NexxusApplicationModelDef {
+  fields: NexxusModelDef;
+  subscribable?: boolean;
+  transient?: boolean;
+}
+
 export interface NexxusApplicationSchema {
-  [modelName: string]: NexxusModelDef;
+  [modelName: string]: NexxusApplicationModelDef;
 }
 
 export interface NexxusUserTypeConfig {
@@ -72,12 +99,41 @@ export class NexxusApplication extends NexxusBuiltinModel<INexxusApplication> {
       throw new Error('Application schema cannot be empty');
     }
 
-    // Reject any app-model schema that declares a field with a Nexxus-reserved
-    // name. These names are managed by the system (id/createdAt/updatedAt by
-    // BaseModel, type/appId/userId by the API/Worker, version by the database
-    // adapter) and cannot be redefined by app developers.
+    // Validate each per-model entry: `fields` presence + shape, per-model
+    // flags, reserved-name check on declared fields, and the invalid flag
+    // combo (subscribable=false + transient=true).
     for (const [modelName, modelDef] of Object.entries(data.schema)) {
-      for (const fieldName of Object.keys(modelDef)) {
+      if (!modelDef || typeof modelDef !== 'object') {
+        throw new Error(`Application schema: model "${modelName}" must be an object`);
+      }
+
+      if (!modelDef.fields || typeof modelDef.fields !== 'object') {
+        throw new Error(`Application schema: model "${modelName}" must have a "fields" object`);
+      }
+
+      if (modelDef.subscribable !== undefined && typeof modelDef.subscribable !== 'boolean') {
+        throw new Error(`Application schema: model "${modelName}" "subscribable" must be a boolean if provided`);
+      }
+
+      if (modelDef.transient !== undefined && typeof modelDef.transient !== 'boolean') {
+        throw new Error(`Application schema: model "${modelName}" "transient" must be a boolean if provided`);
+      }
+
+      if (modelDef.subscribable === false && modelDef.transient === true) {
+        throw new Error(
+          `Application schema: model "${modelName}" cannot be both non-subscribable and transient — ` +
+          `a create-only model that clients also can't subscribe to has no observable shape`
+        );
+      }
+
+      modelDef.subscribable = modelDef.subscribable ?? true;
+      modelDef.transient = modelDef.transient ?? false;
+
+      // Reject any app-model schema that declares a field with a Nexxus-reserved
+      // name. These names are managed by the system (id/createdAt/updatedAt by
+      // BaseModel, type/appId/userId by the API/Worker, version by the database
+      // adapter) and cannot be redefined by app developers.
+      for (const fieldName of Object.keys(modelDef.fields)) {
         if (NEXXUS_RESERVED_FIELD_NAMES.has(fieldName)) {
           throw new Error(
             `Application schema: model "${modelName}" declares a field "${fieldName}", ` +
@@ -187,6 +243,12 @@ export class NexxusApplication extends NexxusBuiltinModel<INexxusApplication> {
    * Runtime field schema for one of the developer-declared models in this
    * application's `schema` field. Built-in models (user, application) have
    * their own static `getModelSchema` and are not resolved here.
+   *
+   * When the model is `subscribable: false`, every primitive field is
+   * force-marked `filterable: true` recursively — that's how the
+   * "traditional-DB, all-fields-filterable" behaviour lands in downstream
+   * FilterQuery validation without those callers needing to know about
+   * the flag.
    */
   public getAppModelSchema(modelType: string): NexxusModelDef {
     const appModelDef = this.data.schema[modelType];
@@ -195,13 +257,60 @@ export class NexxusApplication extends NexxusBuiltinModel<INexxusApplication> {
       throw new Error(`Unknown app model type: ${modelType}`);
     }
 
-    const appModelSchema = structuredClone(appModelDef);
+    const fields = structuredClone(appModelDef.fields);
 
     if (this.hasAuthEnabled()) {
-      appModelSchema.userId = { type: 'string', required: true, filterable: true };
+      fields.userId = { type: 'string', required: true, filterable: true };
     }
 
-    return appModelSchema;
+    if (appModelDef.subscribable === false) {
+      NexxusApplication.markAllPrimitivesFilterable(fields);
+    }
+
+    return fields;
+  }
+
+  /**
+   * Recursively set `filterable: true` on every primitive field def in the
+   * given schema. Arrays are skipped (the query DSL doesn't filter into
+   * arrays). Mutates in place — callers pass a clone.
+   */
+  private static markAllPrimitivesFilterable(fields: Record<string, NexxusFieldDef>): void {
+    for (const def of Object.values(fields)) {
+      if (def.type === 'object') {
+        NexxusApplication.markAllPrimitivesFilterable(def.properties);
+      } else if (def.type !== 'array') {
+        (def as PrimitiveFieldDef).filterable = true;
+      }
+    }
+  }
+
+  /**
+   * Whether the given model type accepts subscribe/unsubscribe. Default:
+   * true (existing behaviour when the flag is unspecified).
+   */
+  public isSubscribable(modelType: string): boolean {
+    const appModelDef = this.data.schema[modelType];
+
+    if (!appModelDef) {
+      throw new Error(`Unknown app model type: ${modelType}`);
+    }
+
+    return appModelDef.subscribable !== false;
+  }
+
+  /**
+   * Whether the given model type is create-only (update/delete routes
+   * reject it). Default: false.
+   */
+  public isTransient(modelType: string): boolean {
+    const appModelDef = this.data.schema[modelType];
+
+    if (!appModelDef) {
+      throw new Error(`Unknown app model type: ${modelType}`);
+    }
+
+    return appModelDef.transient === true;
   }
 
   /**
@@ -213,7 +322,7 @@ export class NexxusApplication extends NexxusBuiltinModel<INexxusApplication> {
   }
 
   public getAppModelFieldType(modelType: string, fieldPath: string): string | undefined {
-    const appModelFieldType = Dot.getProperty(this.getSchema(), `${modelType}.${fieldPath}.type`);
+    const appModelFieldType = Dot.getProperty(this.getSchema(), `${modelType}.fields.${fieldPath}.type`);
 
     return appModelFieldType as string | undefined;
   }
@@ -226,22 +335,25 @@ export class NexxusApplication extends NexxusBuiltinModel<INexxusApplication> {
       return filterableFields;
     }
 
-    // Recursive helper to traverse nested fields
+    // Route through `getAppModelSchema` so we pick up the auto-marked
+    // filterable fields on non-subscribable models (and the userId
+    // injection when auth is enabled). The traversal below then only
+    // needs to look at the `filterable` flag.
+    const fields = this.getAppModelSchema(modelType);
+
     const collectFilterableFields = (
-      fields: Record<string, NexxusFieldDef>,
+      subFields: Record<string, NexxusFieldDef>,
       prefix: string = ''
     ): void => {
-      for (const [fieldName, fieldDef] of Object.entries(fields)) {
+      for (const [fieldName, fieldDef] of Object.entries(subFields)) {
         const fieldPath = prefix ? `${prefix}.${fieldName}` : fieldName;
 
         if (fieldDef.type === 'object') {
-          // Recurse into nested object
           collectFilterableFields(fieldDef.properties, fieldPath);
         } else if (fieldDef.type === 'array') {
           // Skip arrays entirely (not filterable)
           continue;
         } else {
-          // Primitive field - check filterable flag
           if (fieldDef.filterable) {
             filterableFields.add(fieldPath);
           }
@@ -249,7 +361,7 @@ export class NexxusApplication extends NexxusBuiltinModel<INexxusApplication> {
       }
     };
 
-    collectFilterableFields(modelDef);
+    collectFilterableFields(fields);
 
     return filterableFields;
   }

--- a/src/database/package.json
+++ b/src/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mayhem93/nexxus-database-lib",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Database adapters for Nexxus",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -46,7 +46,7 @@
     "winston": "^3.18.3"
   },
   "peerDependencies": {
-    "@mayhem93/nexxus-core-lib": "~0.0.6"
+    "@mayhem93/nexxus-core-lib": "~0.0.7"
   },
   "repository": {
     "type": "git",

--- a/src/database/src/lib/ElasticsearchDb.ts
+++ b/src/database/src/lib/ElasticsearchDb.ts
@@ -496,7 +496,7 @@ export class NexxusElasticsearchDb extends NexxusDatabaseAdapter<ElasticsearchCo
             break;
 
           case 'incr':
-            if (fieldType === 'number' || fieldType === 'date') {
+            if (fieldType === 'int' || fieldType === 'float' || fieldType === 'date') {
               scriptLine = `if (ctx._source.${path} == null) { ctx._source.${path} = ${patchData.value[idx]}; } ctx._source.${path} += params.${paramName}`;
             } else {
               NexxusElasticsearchDb.logger.warn(`Incr operation not supported for field type: ${fieldType}`, NexxusDatabaseAdapter.loggerLabel);
@@ -505,7 +505,7 @@ export class NexxusElasticsearchDb extends NexxusDatabaseAdapter<ElasticsearchCo
             break;
 
           case 'decr':
-            if (fieldType === 'number' || fieldType === 'date') {
+            if (fieldType === 'int' || fieldType === 'float' || fieldType === 'date') {
               scriptLine = `if (ctx._source.${path} == null) { ctx._source.${path} = ${patchData.value[idx]}; } ctx._source.${path} -= params.${paramName}`;
             } else {
               NexxusElasticsearchDb.logger.warn(`Decr operation not supported for field type: ${fieldType}`, NexxusDatabaseAdapter.loggerLabel);

--- a/src/database/src/lib/ElasticsearchDbBootstrapper.ts
+++ b/src/database/src/lib/ElasticsearchDbBootstrapper.ts
@@ -17,7 +17,7 @@ import { NexxusDatabaseAdapter, NexxusDatabaseBootstrapper } from './DatabaseAda
  * more machinery than clarity.
  */
 type EsFieldMapping =
-  | { type: 'keyword' | 'boolean' | 'date' | 'double' }
+  | { type: 'keyword' | 'boolean' | 'date' | 'double' | 'long' }
   | { type: 'object'; properties?: Record<string, EsFieldMapping>; enabled?: boolean }
   | { properties: Record<string, EsFieldMapping> };
 
@@ -34,11 +34,11 @@ type EsIndexMapping = {
  * Explicit mappings are the whole point of this class. The runtime adapter
  * lets ES dynamic-map fields on first write, which loses precision and
  * breaks filter semantics we care about (strings default to `text` +
- * `keyword` multi-field, integers become `long`, decimals become `float`).
- * The bootstrapper declares mappings up front — keyword-only strings, no
- * analyzers anywhere, `double` for every numeric — and installs dynamic
- * templates so any subtree left open in the Nexxus schema inherits the
- * same policy when ES eventually infers a mapping for it.
+ * `keyword` multi-field, decimals default to `float`). The bootstrapper
+ * declares mappings up front — keyword-only strings, no analyzers
+ * anywhere, `long` for `int` and `double` for `float` — and installs
+ * dynamic templates so any subtree left open in the Nexxus schema
+ * inherits the same policy when ES eventually infers a mapping for it.
  */
 export class NexxusElasticsearchDbBootstrapper extends NexxusDatabaseBootstrapper {
   private static readonly LOGGER_LABEL = 'NxxDbBootstrap';
@@ -51,7 +51,7 @@ export class NexxusElasticsearchDbBootstrapper extends NexxusDatabaseBootstrappe
    */
   private static readonly DYNAMIC_TEMPLATES: Array<Partial<Record<string, estypesWithBody.MappingDynamicTemplate>>> = [
     { strings_as_keyword: { match_mapping_type: 'string', mapping: { type: 'keyword' } } },
-    { integers_as_double: { match_mapping_type: 'long',   mapping: { type: 'double'  } } },
+    { integers_as_long:   { match_mapping_type: 'long',   mapping: { type: 'long'    } } },
     { floats_as_double:   { match_mapping_type: 'double', mapping: { type: 'double'  } } },
   ];
 
@@ -208,7 +208,8 @@ export class NexxusElasticsearchDbBootstrapper extends NexxusDatabaseBootstrappe
   private static fieldToEsMapping(def: NexxusFieldDef): EsFieldMapping {
     switch (def.type) {
       case 'string':  return { type: 'keyword' };
-      case 'number':  return { type: 'double'  };
+      case 'int':     return { type: 'long'  };
+      case 'float':   return { type: 'double'  };
       case 'boolean': return { type: 'boolean' };
       case 'date':    return { type: 'date'    };
       case 'array':

--- a/src/database/src/lib/ElasticsearchDbBootstrapper.ts
+++ b/src/database/src/lib/ElasticsearchDbBootstrapper.ts
@@ -119,10 +119,27 @@ export class NexxusElasticsearchDbBootstrapper extends NexxusDatabaseBootstrappe
     const schema = app.getSchema();
 
     // Per-app-per-model indices — one per model type the app declares.
-    for (const [modelType, modelSchema] of Object.entries(schema)) {
+    // The Application schema now wraps field defs under a `fields` key so
+    // we can carry per-model flags (`subscribable`, `transient`); the ES
+    // index mapping only cares about the field defs.
+    //
+    // Transient models are skipped — they're notification-shaped, created
+    // by the API and published directly to the transport-manager without
+    // ever hitting the writer or the DB, so an index would sit empty
+    // forever. See `NexxusApplication` for the flag semantics.
+    for (const [modelType, modelDef] of Object.entries(schema)) {
+      if (modelDef.transient === true) {
+        NexxusDatabaseAdapter.logger.info(
+          `Skipping index creation for transient model "${modelType}" on app ${appId}`,
+          NexxusElasticsearchDbBootstrapper.LOGGER_LABEL,
+        );
+
+        continue;
+      }
+
       await this.createIndexIfMissing(
         `${NEXXUS_PREFIX_LC}-app-${appId}-${modelType}`,
-        this.buildMapping(modelSchema, true),
+        this.buildMapping(modelDef.fields, true),
       );
     }
 

--- a/src/message_queue/package.json
+++ b/src/message_queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mayhem93/nexxus-message-queue-lib",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Message queue adapters for Nexxus backend",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -41,7 +41,7 @@
     "tslib": "2.8.1"
   },
   "peerDependencies": {
-    "@mayhem93/nexxus-core-lib": "~0.0.6"
+    "@mayhem93/nexxus-core-lib": "~0.0.7"
   },
   "repository": {
     "type": "git",

--- a/src/message_queue/package.json
+++ b/src/message_queue/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "amqplib": "^0.10.9",
+    "lz4-napi": "^2.8.0",
     "tslib": "2.8.1"
   },
   "peerDependencies": {

--- a/src/message_queue/src/index.ts
+++ b/src/message_queue/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/MessageQueueAdapter';
 export * from './lib/RabbitMq';
 export * from './lib/RabbitMqBootstrapper';
+export * from './lib/Compression';

--- a/src/message_queue/src/lib/Compression.ts
+++ b/src/message_queue/src/lib/Compression.ts
@@ -1,0 +1,76 @@
+import { compress as lz4Compress, uncompress as lz4Uncompress } from 'lz4-napi';
+
+/**
+ * All algo names this codebase currently knows how to construct. Kept as a
+ * const union so the config schema and the runtime switch below stay in
+ * lock-step; add a new algo here first, then a case in the constructor and
+ * one each in `compress` / `decompress`.
+ */
+export const NEXXUS_COMPRESSION_ALGOS = ['lz4'] as const;
+
+export type NexxusCompressionAlgo = typeof NEXXUS_COMPRESSION_ALGOS[number];
+
+/**
+ * Per-adapter compression config. Lives on the MQ adapter config block.
+ * When `enabled` is false, `algo` is still required so operators can flip
+ * the switch back on without re-authoring the block. Absent config
+ * altogether = disabled.
+ */
+export interface NexxusCompressionConfig {
+  enabled: boolean;
+  algo: NexxusCompressionAlgo;
+  /** Algo-specific tunables. Shape is up to the algo. */
+  options: Record<string, any>;
+}
+
+/**
+ * Single home for every compression algo the MQ layer supports. New algos
+ * land here — one case in the constructor validator plus one branch each
+ * in `compress` and `decompress`.
+ *
+ * Chosen shape: one class with an internal switch, not one class per algo.
+ * The algos share nothing structurally (no shared state, no per-algo
+ * lifecycle beyond the config), so subclassing would just add ceremony.
+ *
+ * Compression policy is deployment-wide: every producer and every consumer
+ * in the deployment must run the same algo config. Rolling a change means
+ * draining the queues first — messages carry no per-message algo marker.
+ */
+export class NexxusMessageCompressor {
+  private readonly algo: NexxusCompressionAlgo;
+  private readonly options: Record<string, any>;
+
+  constructor(config: NexxusCompressionConfig) {
+    if (!config.enabled) {
+      throw new Error(
+        'NexxusMessageCompressor: must not be constructed when compression.enabled is false — callers should check the flag first'
+      );
+    }
+
+    if (!(NEXXUS_COMPRESSION_ALGOS as readonly string[]).includes(config.algo)) {
+      throw new Error(
+        `NexxusMessageCompressor: unsupported algo "${config.algo}". Supported: ${NEXXUS_COMPRESSION_ALGOS.join(', ')}`
+      );
+    }
+
+    this.algo = config.algo;
+    this.options = config.options;
+  }
+
+  public compress(input: Buffer): Promise<Buffer> {
+    switch (this.algo) {
+      case 'lz4':
+        // Standard-mode LZ4. Deliberately not passing the HC/dictionary
+        // options — target is ~50% ratio at minimum CPU cost. `options`
+        // is unused today; wired up so future algos can consume it.
+        return lz4Compress(input);
+    }
+  }
+
+  public decompress(input: Buffer): Promise<Buffer> {
+    switch (this.algo) {
+      case 'lz4':
+        return lz4Uncompress(input);
+    }
+  }
+}

--- a/src/message_queue/src/lib/MessageQueueAdapter.ts
+++ b/src/message_queue/src/lib/MessageQueueAdapter.ts
@@ -9,6 +9,18 @@ import {
   FatalErrorException,
 } from '@mayhem93/nexxus-core-lib';
 
+import { NexxusMessageCompressor, NexxusCompressionConfig } from './Compression';
+
+/**
+ * Shared shape every MQ adapter's config extends. Currently just adds the
+ * optional `compression` block; future MQ-generic fields (message TTL,
+ * retry policy, etc.) belong here too so every concrete adapter picks
+ * them up.
+ */
+export type NexxusMessageQueueConfig = NexxusConfig & {
+  compression?: NexxusCompressionConfig;
+};
+
 export type NexxusMessageQueueAdapterEvents = {
   connect: [];
   disconnect: [];
@@ -26,7 +38,7 @@ export type NexxusMessageQueueAdapterStats = {
 };
 
 export abstract class NexxusMessageQueueAdapter<
-  T extends NexxusConfig,
+  T extends NexxusMessageQueueConfig,
   Ev extends NexxusMessageQueueAdapterEvents,
   TStats extends NexxusMessageQueueAdapterStats
 >
@@ -37,6 +49,18 @@ export abstract class NexxusMessageQueueAdapter<
   protected abstract reconnectDelayMs: number;
 
   public static logger: NexxusBaseLogger<any>;
+
+  /**
+   * Compressor used by `serializePayload` / `deserializePayload`. Non-null
+   * only when `config.compression.enabled === true`. Deployment-wide
+   * policy: every node must have the same setting, otherwise producers
+   * and consumers will talk past each other.
+   *
+   * Definite-assignment `!` — assigned unconditionally in the constructor
+   * (to either an instance or `null`), TS just can't see through the
+   * ternary from the property declaration site.
+   */
+  protected readonly compressor!: NexxusMessageCompressor | null;
 
   /** Retry timer for the reconnection loop. Null when we're not actively trying. */
   private retryTimer: NodeJS.Timeout | null = null;
@@ -63,6 +87,52 @@ export abstract class NexxusMessageQueueAdapter<
     }
 
     NexxusMessageQueueAdapter.logger = services.logger;
+
+    this.compressor = this.config.compression?.enabled
+      ? new NexxusMessageCompressor(this.config.compression)
+      : null;
+
+    if (this.compressor) {
+      NexxusMessageQueueAdapter.logger.info(
+        `MQ compression enabled: algo=${this.config.compression!.algo}`,
+        NexxusMessageQueueAdapter.loggerLabel,
+      );
+    }
+  }
+
+  /**
+   * Encode a typed payload for the wire. JSON → Buffer, then compress if
+   * enabled. Concrete adapters call this in their `publishMessage` in
+   * place of the raw `Buffer.from(JSON.stringify(...))` so compression
+   * policy stays in one place.
+   */
+  protected serializePayload<Q extends NexxusQueueName>(
+    payload: NexxusQueuePayload<Q>,
+  ): Promise<Buffer> {
+    const jsonBuf = Buffer.from(JSON.stringify(payload));
+
+    if (!this.compressor) {
+      return Promise.resolve(jsonBuf);
+    }
+
+    return this.compressor.compress(jsonBuf);
+  }
+
+  /**
+   * Decode a wire buffer back to the typed payload. Decompress if enabled,
+   * then JSON.parse. Concrete adapters call this in their consume loop
+   * in place of the raw `JSON.parse(buf.toString())`.
+   *
+   * Whether the buffer is actually compressed is a deployment-wide
+   * property, not per-message — this method trusts `this.compressor`
+   * being non-null to mean "everything on the wire is compressed."
+   */
+  protected async deserializePayload<Q extends NexxusQueueName>(
+    buf: Buffer,
+  ): Promise<NexxusQueuePayload<Q>> {
+    const jsonBuf = this.compressor ? await this.compressor.decompress(buf) : buf;
+
+    return JSON.parse(jsonBuf.toString()) as NexxusQueuePayload<Q>;
   }
 
   /**

--- a/src/message_queue/src/lib/RabbitMq.ts
+++ b/src/message_queue/src/lib/RabbitMq.ts
@@ -1,7 +1,6 @@
 import {
   ConfigCliArgs,
   ConfigEnvVars,
-  NexxusConfig,
   INexxusBaseServices,
   NexxusQueueName,
   NexxusQueuePayload,
@@ -10,6 +9,7 @@ import {
   NexxusMessageQueueAdapter,
   NexxusMessageQueueAdapterEvents,
   NexxusMessageQueueAdapterStats,
+  NexxusMessageQueueConfig,
   NexxusQueueMessage
 } from './MessageQueueAdapter';
 import {
@@ -27,7 +27,7 @@ type RabbitMQConfig = {
   user: string;
   password: string;
   managementPort: number;
-} & NexxusConfig;
+} & NexxusMessageQueueConfig;
 
 export type RabbitMqMetadata = {
   fields: amqplib.MessageFields;
@@ -175,14 +175,20 @@ export class NexxusRabbitMq extends NexxusMessageQueueAdapter<RabbitMQConfig, Ne
     message: NexxusQueuePayload<Q>,
     metadata?: amqplib.Options.Publish
   ): Promise<void> {
-    // Implementation for publishing a message to a RabbitMQ queue
-    const messageBuffer = Buffer.from(JSON.stringify(message));
+    // `serializePayload` on the base handles JSON encode + optional
+    // compression per the adapter's config. Content-type reflects the
+    // post-compression wire shape so any inspector (RabbitMQ management
+    // UI, tracing) knows not to try JSON-parsing the raw bytes.
+    const messageBuffer = await this.serializePayload(message);
 
-    NexxusRabbitMq.logger.debug(`Publishing message to RabbitMQ queue ${queueName}: ${messageBuffer.toString()}`, NexxusRabbitMq.loggerLabel);
+    NexxusRabbitMq.logger.debug(
+      `Publishing message to RabbitMQ queue ${queueName} (${messageBuffer.length} bytes${this.compressor ? ', compressed' : ''})`,
+      NexxusRabbitMq.loggerLabel,
+    );
 
     const options : amqplib.Options.Publish = {
       persistent: true,
-      contentType: 'application/json',
+      contentType: this.compressor ? 'application/octet-stream' : 'application/json',
       ...metadata || {}
     };
 
@@ -240,7 +246,7 @@ export class NexxusRabbitMq extends NexxusMessageQueueAdapter<RabbitMQConfig, Ne
     }
   }
 
-  async createVolatileQueue(name: string): Promise<void> {
+  public async createVolatileQueue(name: string): Promise<void> {
     if (!this.channel) {
       throw new Error('RabbitMQ channel not available — call connect() before createVolatileQueue()');
     }
@@ -268,7 +274,7 @@ export class NexxusRabbitMq extends NexxusMessageQueueAdapter<RabbitMQConfig, Ne
     );
   }
 
-  async deleteQueue(name: string): Promise<void> {
+  public async deleteQueue(name: string): Promise<void> {
     if (!this.channel) {
       throw new Error('RabbitMQ channel not available — call connect() before deleteQueue()');
     }
@@ -284,13 +290,15 @@ export class NexxusRabbitMq extends NexxusMessageQueueAdapter<RabbitMQConfig, Ne
     );
   }
 
-  async consumeMessages<Q extends NexxusQueueName>(
+  public async consumeMessages<Q extends NexxusQueueName>(
     queueName: Q,
     onMessage: (message: NexxusQueueMessage<NexxusQueuePayload<Q>>) => Promise<void>
   ) : Promise<void> {
     await this.channel?.consume(queueName, async msg => {
       if (msg !== null) {
-        const payload = JSON.parse(msg.content.toString()) as NexxusQueuePayload<Q>;
+        // `deserializePayload` on the base handles decompression (when
+        // enabled) + JSON.parse, so compression policy stays in one place.
+        const payload = await this.deserializePayload<Q>(msg.content);
         const metadata : RabbitMqMetadata = {
           fields: msg.fields,
           properties: msg.properties

--- a/src/message_queue/src/schemas/rabbitmq.schema.json
+++ b/src/message_queue/src/schemas/rabbitmq.schema.json
@@ -16,6 +16,19 @@
     "managementPort": {
       "type": "number",
       "default": 15672
+    },
+    "compression": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "algo": {
+          "type": "string",
+          "enum": ["lz4"]
+        },
+        "options": { "type": "object", "default": {} }
+      },
+      "required": ["enabled", "algo"],
+      "additionalProperties": false
     }
   },
   "required": [

--- a/src/worker/package.json
+++ b/src/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mayhem93/nexxus-worker-lib",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Library for Nexxus workers that process data",
   "main": "dist-cjs/index.js",
   "module": "dist-esm/index.js",
@@ -33,9 +33,9 @@
     "ws": "^8.18.3"
   },
   "peerDependencies": {
-    "@mayhem93/nexxus-core-lib": "~0.0.6",
-    "@mayhem93/nexxus-database-lib": "~0.0.7",
-    "@mayhem93/nexxus-message-queue-lib": "~0.0.6",
+    "@mayhem93/nexxus-core-lib": "~0.0.7",
+    "@mayhem93/nexxus-database-lib": "~0.0.8",
+    "@mayhem93/nexxus-message-queue-lib": "~0.0.7",
     "@mayhem93/nexxus-redis": "~0.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Core:

* Split "number" data type into "int" and "float" on models
* App schema updated: moved model fields to its own key in the object and added "subscribable" and "transient" flags for each model

Database:

* Updated data types to use "int"/"float" for ES adapter and ES bootstrapper
* ES bootstrapper shouldn't create indices for models that are transient

MQ:

* Added message queue compression (lz4)

API:

* Removed **getOnly** from subscribe route
* Added `/model/{type}/search` for searching models
* Added support for handling subscribable/transient models

Worker:

* Updated nexxus dependencies